### PR TITLE
Add specs for backend, frontend and database

### DIFF
--- a/backend/spec.md
+++ b/backend/spec.md
@@ -1,0 +1,28 @@
+# Backend Specification
+
+The backend is built with **Node.js** and **Express**. It exposes REST APIs and Socket.IO events for real-time gameplay.
+
+## Features
+- Authentication with JWT tokens
+- Crash game engine with provably fair rounds
+- Wallet management and M-Pesa integration
+- User profiles and settings
+- Historical game data and bet tracking
+
+## Architecture
+- `server.js` – Express app setup, routes, and Socket.IO initialization
+- `game.js` – Main game server controlling rounds, multipliers and crash logic
+- `routes/` – REST API endpoints for auth, bets, game data, wallet and M-Pesa
+- `sockets/` – WebSocket handlers for placing bets and receiving game updates
+- `models/` – Data access helpers for Postgres tables
+- `services/` – External integrations (e.g. M-Pesa payments)
+
+### Running
+Install dependencies and start the server:
+```bash
+cd backend
+npm install
+npm run dev  # with nodemon
+```
+The server listens on port `4000` by default and connects to the database defined in `.env`.
+

--- a/database/spec.md
+++ b/database/spec.md
@@ -1,0 +1,23 @@
+# Database Specification
+
+The project uses **PostgreSQL** for persistent storage. Schema creation scripts live in `database/`.
+
+## Features
+- User accounts with balances
+- Game rounds and bet history
+- Wallet transactions and M-Pesa records
+- Session and settings tables
+
+## Schema Files
+- `init.sql` – Creates all tables and indexes
+- `migrations/` – Additional migration scripts
+- `run-migrations.js` – Helper script to apply migrations
+
+### Usage
+Start the database using Docker and run migrations:
+```bash
+docker compose up -d
+node database/run-migrations.js
+```
+Adminer is available at `http://localhost:8080` for database inspection.
+

--- a/frontend/spec.md
+++ b/frontend/spec.md
@@ -1,0 +1,27 @@
+# Frontend Specification
+
+The frontend is a **React** application that connects to the backend via Socket.IO and REST APIs.
+
+## Features
+- Real-time crash game interface with multiplier graph
+- Login and registration flows using AuthContext
+- Wallet views for balance, deposits and withdrawals
+- Live bet sidebar and game history list
+- Responsive design with reusable components
+
+## Architecture
+- `src/StakeOutBet.js` – Main component handling socket connection and game logic
+- `src/components/` – UI components such as game graph, controls and history
+- `src/config/` – Client-side constants
+- `src/utils/` – Helper functions for rendering the graph
+- `AuthContext.jsx` – Provides authentication state and API helpers
+
+### Running
+Install dependencies and start the development server:
+```bash
+cd frontend
+npm install
+npm start
+```
+The app runs at `http://localhost:3000` and expects the backend on port `4000`.
+


### PR DESCRIPTION
## Summary
- document architecture overview for each component
- add specs for backend, frontend and database modules

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888d937cef0832f914458c545eca892