### PR TITLE
Improve cashout display

### DIFF
--- a/frontend/src/components/Controls.js
+++ b/frontend/src/components/Controls.js
@@ -40,6 +40,9 @@ const Controls = ({
   const showBetButton = !hasActiveBet;
   const showCashOutButton = hasActiveBet;
 
+  // Display amount should reflect the actual placed bet when active
+  const displayBetAmount = hasActiveBet ? currentBetAmount : bet;
+
   // Quick amount buttons matching the design
   const quickAmounts = [100, 200, 500, 10000];
 
@@ -89,7 +92,7 @@ const Controls = ({
               </button>
 
               <div className="mx-6 text-center">
-                <div className="text-2xl font-bold text-white">{bet.toFixed(2)}</div>
+                <div className="text-2xl font-bold text-white">{displayBetAmount.toFixed(2)}</div>
               </div>
 
               <button
@@ -191,10 +194,10 @@ const Controls = ({
                     if (canCashOut) e.target.style.backgroundColor = '#ef4444';
                   }}
                 >
-                  {canCashOut 
-                    ? `Cash Out ${(bet * multiplier).toFixed(2)} KES`
+                  {canCashOut
+                    ? `Cash Out ${(displayBetAmount * multiplier).toFixed(2)} KES`
                     : isEnded
-                      ? `Round Ended - ${(bet * multiplier).toFixed(2)} KES`
+                      ? `Round Ended - ${(displayBetAmount * multiplier).toFixed(2)} KES`
                       : `Waiting...`
                   }
                 </button>

--- a/frontend/src/components/GameGraph.js
+++ b/frontend/src/components/GameGraph.js
@@ -351,6 +351,17 @@ const GameGraph = ({ multiplier, dangerLevel, getDynamicColor }) => {
         r={dangerLevel === 'extreme' ? 1.2 : dangerLevel === 'risky' ? 1 : 0.8}
         fill={dynamicColor}
       />
+
+      {/* Multiplier label near the latest point */}
+      <text
+        x={Math.min(lastPoint.cx + 2, 95)}
+        y={Math.max(lastPoint.cy - 2, 5)}
+        fill={dynamicColor}
+        fontSize="4"
+        fontWeight="bold"
+      >
+        {multiplier.toFixed(2)}x
+      </text>
     </svg>
   );
 };


### PR DESCRIPTION
## Summary
- use actual bet amount when calculating cashout button
- show the current multiplier directly on the game graph

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6888e043b4bc832f865036b1f08ea6d4