### PR TITLE
Improve cashout display

### DIFF
--- a/frontend/src/components/Controls.js
+++ b/frontend/src/components/Controls.js
@@ -40,6 +40,9 @@ const Controls = ({
   const showBetButton = !hasActiveBet;
   const showCashOutButton = hasActiveBet;
 
+  // Display amount should reflect the actual placed bet when active
+  const displayBetAmount = hasActiveBet ? currentBetAmount : bet;
+
   // Quick amount buttons matching the design
   const quickAmounts = [100, 200, 500, 10000];
 
@@ -89,7 +92,7 @@ const Controls = ({
               </button>
 
               <div className="mx-6 text-center">
-                <div className="text-2xl font-bold text-white">{bet.toFixed(2)}</div>
+                <div className="text-2xl font-bold text-white">{displayBetAmount.toFixed(2)}</div>
               </div>
 
               <button
@@ -191,10 +194,10 @@ const Controls = ({
                     if (canCashOut) e.target.style.backgroundColor = '#ef4444';
                   }}
                 >
-                  {canCashOut 
-                    ? `Cash Out ${(bet * multiplier).toFixed(2)} KES`
+                  {canCashOut
+                    ? `Cash Out ${(displayBetAmount * multiplier).toFixed(2)} KES`
                     : isEnded
-                      ? `Round Ended - ${(bet * multiplier).toFixed(2)} KES`
+                      ? `Round Ended - ${(displayBetAmount * multiplier).toFixed(2)} KES`
                       : `Waiting...`
                   }
                 </button>

--- a/frontend/src/components/GameGraph.js
+++ b/frontend/src/components/GameGraph.js
@@ -351,6 +351,32 @@ const GameGraph = ({ multiplier, dangerLevel, getDynamicColor }) => {
         r={dangerLevel === 'extreme' ? 1.2 : dangerLevel === 'risky' ? 1 : 0.8}
         fill={dynamicColor}
       />
+
+      {/* Multiplier label centered on graph */}
+      <text
+        x="50"
+        y="50"
+        fill={dynamicColor}
+        fontSize="6"
+        fontWeight="bold"
+        textAnchor="middle"
+        dominantBaseline="middle"
+      >
+        {multiplier.toFixed(2)}x
+      </text>
+
+      {/* Rocket indicator at the latest point */}
+      <g
+        transform={`translate(${lastPoint.cx - 1.2}, ${lastPoint.cy - 2}) scale(0.1)`}
+        fill="none"
+        stroke={dynamicColor}
+        strokeWidth="1"
+      >
+        <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
+        <path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
+        <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />
+        <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
+      </g>
     </svg>
   );
 };

--- a/frontend/src/components/MultiplierDisplay.js
+++ b/frontend/src/components/MultiplierDisplay.js
@@ -65,9 +65,9 @@ const MultiplierDisplay = ({ multiplier, dangerLevel }) => {
         dangerLevel === 'extreme' ? 'animate-pulse' : ''
       }`}
       style={{
-        top: '10px',
+        top: '50%',
         left: '50%',
-        transform: `translateX(-50%) translate(${shake.x}px, ${shake.y}px)`,
+        transform: `translate(-50%, -50%) translate(${shake.x}px, ${shake.y}px)`,
         fontSize: `${fontSize}px`,
         color: dynamicColor,
         textShadow: glowEffect,


### PR DESCRIPTION
## Summary
- use actual bet amount when calculating cashout button
- show the current multiplier directly on the game graph
- center the multiplier text in the graph
- add a rocket icon at the latest point

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6888e043b4bc832f865036b1f08ea6d4